### PR TITLE
Improved documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,133 @@
 # Description
 
-A [todo.txt](https://github.com/ginatrapani/todo.txt-cli) command line add-on for marking a task as done, and then
-adding it again, adjusting due dates and deferral dates if desired.
+A [todo.txt](https://github.com/ginatrapani/todo.txt-cli) command line add-on
+for marking a task as done, and then adding it again, adjusting due dates and
+deferral dates if desired.
 
 # Usage
 
     $ todo.sh again N
-Mark item N as done, and then recreate it, with the creation date set
-as todays date, and any existing due date set to today. Deferral date
-is not affected by this operation.
+Mark item N as done, and then recreate it, with the creation date set as today's
+date, and any existing due date set to today. Deferral date is not affected by
+this operation. There is an exception if the item contains an `again:ADJUST`
+tag; see below.
 
-    $ todo.sh again N DAYS
-Mark item N as done, and then recreate it with the creation date set
-as todays date, and any existing due date and deferral date set to
-DAYS days from today.
+    $ todo.sh again N ADJUST
+Mark item N as done, and then recreate it with the creation date set as today's
+date, and any existing due date and deferral date set to ADJUST from today.
 
-    $ todo.sh again N +DAYS
-Mark item N as done, and then recreate it with the creation date set
-as todays date, and any existing due date and deferral date set to
-DAYS days from their previous values.
+    $ todo.sh again N +ADJUST
+Mark item N as done, and then recreate it with the creation date set as today's
+date, and any existing due date and deferral date set to ADJUST from their
+previous values.
 
-The functionality achieved with the command line arguents detailed
-above can also be achieved bya adding an `again:` tag to an item
-in order to get the desired behavior.
+You can also encode the adjustment interval in the task description with the
+`again:` tag.
 
-todo.txt:
-
+    $ todo.sh list 9
     (A) Do important things due:2001-01-01 t:2001-01-01 again:+5
 
+    $ todo.sh again 9
+    9 x 2001-01-03 (A) Do important things due:2001-01-01 t:2001-01-01 again:+5
+    TODO: 9 marked as done.
+    10 (A) Do important things due:2001-01-06 t:2001-01-06 again:+5
+    TODO: 10 added.
+
+But the again tag will be overriden by an adjustment provided on the command
+line.
+
+    $ todo.sh list 9
+    (A) Do important things due:2001-01-01 t:2001-01-01 again:+5
+
+    $ todo.sh again 9 +10
+    9 x 2001-01-03 (A) Do important things due:2001-01-01 t:2001-01-01 again:+5
+    TODO: 9 marked as done.
+    10 (A) Do important things due:2001-01-11 t:2001-01-11 again:+5
+    TODO: 10 added.
+
+## Adjustment Format
+
+The ADJUST argument has the following format:
+
+    (+)X(d|m|y)
+- + = adjust dates relative to current values instead of today's date (optional)
+- X = an integer indicating the magnitude of the adjustment (required)
+- d, m, or y = adjust dates by days, months, or years (optional, default is days if omitted)
+
+Note that dates near the end of the month will drift from 31 to 30 (in months
+with only 30 days) and eventually to 28 (if they are ever scheduled in February
+of a common year, i.e. not a leap year).
+
+    $ todo.sh list 12
+    12 dates on this task will drift due:2014-10-31
+
+    $ todo.sh again 12 +1m
+    12 dates on this task will drift due:2014-11-30  ; only 30 days in November
+
+    $ todo.sh again 12 +2m
+    12 dates on this task will drift due:2015-01-30  ; drift is permanent
+
+    $ todo.sh again 12 +1m
+    12 dates on this task will drift due:2015-02-28  ; common year, only 28 days in February
+
+    $ todo.sh again 12 +31d
+    12 dates on this task will drift due:2015-03-31  ; adjust by days to keep task on the last day of the month
+
+# Examples
+
+Here are some examples that demonstrate how the again add-on works.
+
+    $ date +%F
+    2015-11-12
+
+    $ todo.sh list
+    1 learn something new
+    2 change bathroom towels due:2015-11-15
+    3 deposit paycheck due:2015-11-15
+    4 replace smoke alarm batteries due:2015-10-20
+    5 pay rent due:2015-12-03
+    6 send flowers to Mom for her birthday due:2016-01-14 again:+1y
 
     $ todo.sh again 1
+    1 x 2015-11-12 learn something new
+    TODO: 1 marked as done.
+    7 learn something new
+    TODO: 7 added.
 
-todo.txt:
+    $ todo.sh again 2 14
+    2 x 2015-11-12 change bathroom towels due:2015-11-15
+    TODO: 2 marked as done.
+    8 change bathroom towels due:2015-11-26
+    TODO: 8 added.
 
-    (A) Do important things due:2001-01-06 t:2001-01-06 again:+5
-    (X) Do important things due:2001-01-01 t:2001-01-01 again:+5
+    $ todo.sh again 3 +14
+    3 x 2015-11-12 deposit paycheck due:2015-11-15
+    TODO: 3 marked as done.
+    9 deposit paycheck due:2015-11-29
+    TODO: 9 added.
 
+    $ todo.sh again 4 1y
+    4 x 2015-11-12 replace smoke alarm batteries due:2015-10-20
+    TODO: 4 marked as done.
+    10 replace smoke alarm batteries due:2016-11-12
+    TODO: 10 added.
+
+    $ todo.sh again 5 +1m
+    5 x 2015-11-12 pay rent due:2015-12-03
+    TODO: 5 marked as done.
+    11 pay rent due:2016-01-03
+    TODO: 11 added.
+
+    $ todo.sh again 6
+    6 x 2015-11-12 send flowers to Mom for her birthday due:2016-01-14 again:+1y
+    TODO: 6 marked as done.
+    12 send flowers to Mom for her birthday due:2017-01-14 again:+1y
+    TODO: 12 added.
 
 # Licensing
 
-This add-on is released under the GNU General Public License v.3
-for further details, refer to LICENSE.
+This add-on is released under the GNU General Public License v.3.0. For further
+details, refer to LICENSE.
 
 # Attribution
 

--- a/test/testAgain.sh
+++ b/test/testAgain.sh
@@ -125,17 +125,17 @@ function test_line_without_creation_date()
 
 function test_line_with_creation_date()
 {
-  expected=("command_do_2" "command_add_`date +%Y-%m-%d`_This_is_the_second_line")
+  expected=("command_do_2" "command_add_`date +%F`_This_is_the_second_line")
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 2
   TEST_FAILS=$(($TEST_FAILS + $?))
 
-  expected=("command_do_2" "command_add_`date +%Y-%m-%d`_This_is_the_second_line")
+  expected=("command_do_2" "command_add_`date +%F`_This_is_the_second_line")
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 2 5
   TEST_FAILS=$(($TEST_FAILS + $?))
 
-  expected=("command_do_2" "command_add_`date +%Y-%m-%d`_This_is_the_second_line")
+  expected=("command_do_2" "command_add_`date +%F`_This_is_the_second_line")
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 2 +10
   TEST_FAILS=$(($TEST_FAILS + $?))
@@ -143,7 +143,7 @@ function test_line_with_creation_date()
 
 function test_line_with_creation_date_and_due_date()
 {
-  expected=("command_do_3" "command_add_`date +%Y-%m-%d`_This_is_the_third_line_due:`date +%Y-%m-%d`")
+  expected=("command_do_3" "command_add_`date +%F`_This_is_the_third_line_due:`date +%F`")
 
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 3
@@ -151,9 +151,9 @@ function test_line_with_creation_date_and_due_date()
 
   if [[ "GNU" == $DATE_VERSION ]]
   then
-    expected=("command_do_3" "command_add_`date +%Y-%m-%d`_This_is_the_third_line_due:`date -d '5 days' +%Y-%m-%d`")
+    expected=("command_do_3" "command_add_`date +%F`_This_is_the_third_line_due:`date -d '5 days' +%F`")
   else
-    expected=("command_do_3" "command_add_`date +%Y-%m-%d`_This_is_the_third_line_due:`date -j -v+5d +%Y-%m-%d`")
+    expected=("command_do_3" "command_add_`date +%F`_This_is_the_third_line_due:`date -j -v+5d +%F`")
   fi
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 3 5
@@ -161,9 +161,9 @@ function test_line_with_creation_date_and_due_date()
 
   if [[ "GNU" == $DATE_VERSION ]]
   then
-    expected=("command_do_3" "command_add_`date +%Y-%m-%d`_This_is_the_third_line_due:`date -d '2013-02-02 +10 days' +%Y-%m-%d`")
+    expected=("command_do_3" "command_add_`date +%F`_This_is_the_third_line_due:`date -d '2013-02-02 +10 days' +%F`")
   else
-    expected=("command_do_3" "command_add_`date +%Y-%m-%d`_This_is_the_third_line_due:`date -j -v+10d -f %Y-%m-%d 2013-02-02 +%Y-%m-%d`")
+    expected=("command_do_3" "command_add_`date +%F`_This_is_the_third_line_due:`date -j -v+10d -f %F 2013-02-02 +%F`")
   fi
 
   export TEST_EXPECT=`echo ${expected[@]}`
@@ -173,16 +173,16 @@ function test_line_with_creation_date_and_due_date()
 
 function test_line_with_creation_date_and_due_date_and_deferral_date()
 {
-  expected=("command_do_4" "command_add_`date +%Y-%m-%d`_This_is_the_fourth_line_due:`date +%Y-%m-%d`_t:`date +%Y-%m-%d`")
+  expected=("command_do_4" "command_add_`date +%F`_This_is_the_fourth_line_due:`date +%F`_t:`date +%F`")
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 4
   TEST_FAILS=$(($TEST_FAILS + $?))
 
   if [[ "GNU" == $DATE_VERSION ]]
   then
-    expected=("command_do_4" "command_add_`date +%Y-%m-%d`_This_is_the_fourth_line_due:`date -d '5 days' +%Y-%m-%d`_t:`date -d '5 days' +%Y-%m-%d`")
+    expected=("command_do_4" "command_add_`date +%F`_This_is_the_fourth_line_due:`date -d '5 days' +%F`_t:`date -d '5 days' +%F`")
   else
-    expected=("command_do_4" "command_add_`date +%Y-%m-%d`_This_is_the_fourth_line_due:`date -j -v+5d +%Y-%m-%d`_t:`date -j -v+5d +%Y-%m-%d`")
+    expected=("command_do_4" "command_add_`date +%F`_This_is_the_fourth_line_due:`date -j -v+5d +%F`_t:`date -j -v+5d +%F`")
   fi
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 4 5
@@ -190,9 +190,9 @@ function test_line_with_creation_date_and_due_date_and_deferral_date()
 
   if [[ "GNU" == $DATE_VERSION ]]
   then
-    expected=("command_do_4" "command_add_`date +%Y-%m-%d`_This_is_the_fourth_line_due:`date -d '2013-03-03 +10 days' +%Y-%m-%d`_t:`date -d '2013-02-02 +10 days' +%Y-%m-%d`")
+    expected=("command_do_4" "command_add_`date +%F`_This_is_the_fourth_line_due:`date -d '2013-03-03 +10 days' +%F`_t:`date -d '2013-02-02 +10 days' +%F`")
   else
-    expected=("command_do_4" "command_add_`date +%Y-%m-%d`_This_is_the_fourth_line_due:`date -j -v+10d -f %Y-%m-%d 2013-03-03 +%Y-%m-%d`_t:`date -j -v+10d -f %Y-%m-%d 2013-02-02 +%Y-%m-%d`")
+    expected=("command_do_4" "command_add_`date +%F`_This_is_the_fourth_line_due:`date -j -v+10d -f %F 2013-03-03 +%F`_t:`date -j -v+10d -f %F 2013-02-02 +%F`")
   fi
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 4 +10
@@ -201,16 +201,16 @@ function test_line_with_creation_date_and_due_date_and_deferral_date()
 
 function test_line_with_creation_date_and_deferral_date()
 {
-  expected=("command_do_5" "command_add_`date +%Y-%m-%d`_This_is_the_fifth_line_t:`date +%Y-%m-%d`")
+  expected=("command_do_5" "command_add_`date +%F`_This_is_the_fifth_line_t:`date +%F`")
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 5
   TEST_FAILS=$(($TEST_FAILS + $?))
 
   if [[ "GNU" == $DATE_VERSION ]]
   then
-    expected=("command_do_5" "command_add_`date +%Y-%m-%d`_This_is_the_fifth_line_t:`date -d '5 days' +%Y-%m-%d`")
+    expected=("command_do_5" "command_add_`date +%F`_This_is_the_fifth_line_t:`date -d '5 days' +%F`")
   else
-    expected=("command_do_5" "command_add_`date +%Y-%m-%d`_This_is_the_fifth_line_t:`date -v+5d +%Y-%m-%d`")
+    expected=("command_do_5" "command_add_`date +%F`_This_is_the_fifth_line_t:`date -v+5d +%F`")
   fi
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 5 5
@@ -218,9 +218,9 @@ function test_line_with_creation_date_and_deferral_date()
 
   if [[ "GNU" == $DATE_VERSION ]]
   then
-    expected=("command_do_5" "command_add_`date +%Y-%m-%d`_This_is_the_fifth_line_t:`date -d '2013-04-04 +10 days' +%Y-%m-%d`")
+    expected=("command_do_5" "command_add_`date +%F`_This_is_the_fifth_line_t:`date -d '2013-04-04 +10 days' +%F`")
   else
-    expected=("command_do_5" "command_add_`date +%Y-%m-%d`_This_is_the_fifth_line_t:`date -j -v+10d -f %Y-%m-%d 2013-04-04 +%Y-%m-%d`")
+    expected=("command_do_5" "command_add_`date +%F`_This_is_the_fifth_line_t:`date -j -v+10d -f %F 2013-04-04 +%F`")
   fi
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 5 +10
@@ -229,17 +229,17 @@ function test_line_with_creation_date_and_deferral_date()
 
 function test_line_with_creation_date_and_prio()
 {
-  expected=("command_do_8" "command_add_(A)_`date +%Y-%m-%d`_This_is_the_eighth_line")
+  expected=("command_do_8" "command_add_(A)_`date +%F`_This_is_the_eighth_line")
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 8
   TEST_FAILS=$(($TEST_FAILS + $?))
 
-  expected=("command_do_8" "command_add_(A)_`date +%Y-%m-%d`_This_is_the_eighth_line")
+  expected=("command_do_8" "command_add_(A)_`date +%F`_This_is_the_eighth_line")
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 8 5
   TEST_FAILS=$(($TEST_FAILS + $?))
 
-  expected=("command_do_8" "command_add_(A)_`date +%Y-%m-%d`_This_is_the_eighth_line")
+  expected=("command_do_8" "command_add_(A)_`date +%F`_This_is_the_eighth_line")
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 8 +10
   TEST_FAILS=$(($TEST_FAILS + $?))
@@ -260,9 +260,9 @@ function test_line_with_again_tag()
 {
   if [[ "GNU" == $DATE_VERSION ]]
   then
-    expected=("command_do_6" "command_add_`date +%Y-%m-%d`_This_is_the_sixth_line_due:`date -d '5 days' +%Y-%m-%d`_t:`date -d '5 days' +%Y-%m-%d`_again:5")
+    expected=("command_do_6" "command_add_`date +%F`_This_is_the_sixth_line_due:`date -d '5 days' +%F`_t:`date -d '5 days' +%F`_again:5")
   else
-    expected=("command_do_6" "command_add_`date +%Y-%m-%d`_This_is_the_sixth_line_due:`date -j -v+5d +%Y-%m-%d`_t:`date -j -v+5d +%Y-%m-%d`_again:5")
+    expected=("command_do_6" "command_add_`date +%F`_This_is_the_sixth_line_due:`date -j -v+5d +%F`_t:`date -j -v+5d +%F`_again:5")
   fi
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 6
@@ -270,12 +270,21 @@ function test_line_with_again_tag()
 
   if [[ "GNU" == $DATE_VERSION ]]
   then
-    expected=("command_do_7" "command_add_`date +%Y-%m-%d`_This_is_the_seventh_line_due:`date -d '2013-03-03 +10 days' +%Y-%m-%d`_t:`date -d '2013-02-02 +10 days' +%Y-%m-%d`_again:+10")
+    expected=("command_do_7" "command_add_`date +%F`_This_is_the_seventh_line_due:`date -d '2013-03-03 +10 days' +%F`_t:`date -d '2013-02-02 +10 days' +%F`_again:+10")
   else
-    expected=("command_do_7" "command_add_`date +%Y-%m-%d`_This_is_the_seventh_line_due:`date -j -v+10d -f %Y-%m-%d 2013-03-03 +%Y-%m-%d`_t:`date -j -v+10d -f %Y-%m-%d 2013-02-02 +%Y-%m-%d`_again:+10")
+    expected=("command_do_7" "command_add_`date +%F`_This_is_the_seventh_line_due:`date -j -v+10d -f %F 2013-03-03 +%F`_t:`date -j -v+10d -f %F 2013-02-02 +%F`_again:+10")
   fi
   export TEST_EXPECT=`echo ${expected[@]}`
   $AGAIN 7
+  TEST_FAILS=$(($TEST_FAILS + $?))
+}
+
+function test_command_line_overrides_again_tag()
+{
+  TASK=6
+  expected=("command_do_6" "command_add_`date +%F`_This_is_the_sixth_line_due:2013-03-20_t:2013-02-19_again:5")
+  export TEST_EXPECT=`echo ${expected[@]}`
+  $AGAIN $TASK +17
   TEST_FAILS=$(($TEST_FAILS + $?))
 }
 
@@ -318,6 +327,7 @@ test_line_with_creation_date_and_deferral_date
 test_line_with_creation_date_and_prio
 test_nonexisting_line
 test_line_with_again_tag
+test_command_line_overrides_again_tag
 test_day_stepping
 test_month_stepping
 test_year_stepping


### PR DESCRIPTION
Fixes #4 
Added new examples to illustrate features.
Wrote a new test to prove that an adjustment on the command line will override the again tag in the item description.
Other minor documentation cleanup.
Tested with FreeBSD 10.2, and cygwin tools on Windows 7.