### PR TITLE
Allow adjust dates to be specified in weeks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ line.
 
 The ADJUST argument has the following format:
 
-    (+)X(d|m|y)
+    (+)X(d|w|m|y)
 - + = adjust dates relative to current values instead of today's date (optional)
 - X = an integer indicating the magnitude of the adjustment (required)
-- d, m, or y = adjust dates by days, months, or years (optional, default is days if omitted)
+- d, w, m, or y = adjust dates by days, weeks, months, or years (optional, default is days if omitted)
 
 Note that dates near the end of the month will drift from 31 to 30 (in months
 with only 30 days) and eventually to 28 (if they are ever scheduled in February

--- a/againHelpers.sh
+++ b/againHelpers.sh
@@ -23,7 +23,7 @@ readonly DATE_FORMAT="%F" # %F == %Y-%m-%d for BSD and GNU
 function adjust_date()
 {
   ADJUST_NUM=`expr "$ADJUST" : '+*\([1-9][0-9]*\)'`
-  ADJUST_UNIT=`expr "$ADJUST" : '.*\([dmy]\)'`
+  ADJUST_UNIT=`expr "$ADJUST" : '.*\([dwmy]\)'`
   if [ -z $ADJUST_UNIT ]
   then
     ADJUST_UNIT=d
@@ -33,6 +33,9 @@ function adjust_date()
     case $ADJUST_UNIT in
       d)
         _GNU_UNIT=days
+        ;;
+      w)
+        _GNU_UNIT=weeks
         ;;
       m)
         _GNU_UNIT=months


### PR DESCRIPTION
There's already basically all the support needed to specify adjust dates in weeks -- just had to add the _GNU_UNIT and expand the regular expression. Now you can do `again:+2w` and it'll work exactly like `again:+14d`.