### PR TITLE
Check if creation dates are added automatically

### DIFF
--- a/again
+++ b/again
@@ -95,6 +95,14 @@ function replace_creation_date()
   fi
 }
 
+
+# Remove any creation date of the item in $LINE
+function remove_creation_date()
+{
+  LINE=$(echo "$LINE" | sed "s/^$SED_DATE_RE //g")
+}
+
+
 # Replace any date with $TAG in $LINE by $ADJUST
 function replace_tagged_date()
 {
@@ -138,7 +146,12 @@ determine_date_version
 today
 get_line
 [ "$ADJUST" == "" ] && get_days_from_line
-replace_creation_date
+if [[ "$TODOTXT_DATE_ON_ADD" != 1 ]]
+then
+  replace_creation_date
+else
+  remove_creation_date
+fi
 replace_due_date
 replace_deferral_date
 


### PR DESCRIPTION
If TODOTXT_DATE_ON_ADD is set, the creation date gets added automatically. In this case we should remove the current date instead if replacing it with today or the line will end up with two dates. 