### PR TITLE
Fixes #16

### DIFF
--- a/again
+++ b/again
@@ -159,7 +159,7 @@ if [[ "$LINE" != "" ]]
 then
   "$TODO_FULL_SH" command do "$ITEM"
 
-  if [[ -z "$TODO_NO_AGAIN_IF_NOT_TAGGED" || "$LINE" =~ .*$AGAIN_TAG ]]
+  if [[ -z "$TODO_NO_AGAIN_IF_NOT_TAGGED" || "$LINE" =~ .*" $AGAIN_TAG:" ]]
   then
     "$TODO_FULL_SH" command add "$LINE"
   fi


### PR DESCRIPTION
If the TODO_NO_AGAIN_IF_NOT_TAGGED variable is on, again
will only trigger itself if the AGAIN_TAG appears within
the todo preceded by a space and followed by a colon.