### PR TITLE
Allow overriding AGAIN_TAG from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ will only re-add tasks that have an again tag in them, making the again command
 a drop-in replacement for the `do` command for any tasks without the again tag.
 See Examples for usage.
 
+The environment variable `TODO_AGAIN_TAG` can be set to change the tag
+which is used for the adjustment interval if present.
+
 # Examples
 
 Here are some examples that demonstrate how the again add-on works.

--- a/again
+++ b/again
@@ -21,7 +21,7 @@ source `dirname $0`/againHelpers.sh
 
 readonly SED_DATE_RE="[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}"
 readonly BASH_DATE_RE="[0-9]{4}-[0-9]{2}-[0-9]{2}"
-readonly AGAIN_TAG="again"
+readonly AGAIN_TAG="${TODO_AGAIN_TAG:-again}"
 
 function usage()
 {

--- a/test/sample.txt
+++ b/test/sample.txt
@@ -8,3 +8,4 @@ This is the first line
 (A) 2013-01-01 This is the eighth line
 Line 9 due:2015-08-15
 (A) 2013-03-03 This is the tenth line due:2013-03-03 t:2013-02-02 again:+10
+2013-03-03 This is the eleventh line due:2013-03-03 t:2013-02-02 repeat:+2

--- a/test/testAgain.sh
+++ b/test/testAgain.sh
@@ -288,6 +288,22 @@ function test_command_line_overrides_again_tag()
   TEST_FAILS=$(($TEST_FAILS + $?))
 }
 
+function test_environment_variable_overrides_again_tag()
+{
+  TASK=11
+  export TODO_AGAIN_TAG=repeat
+  if [[ "GNU" == $DATE_VERSION ]]
+  then
+    expected=("command_do_$TASK" "command_add_`date +%F`_This_is_the_eleventh_line_due:`date -d '2013-03-03 +2 days' +%F`_t:`date -d '2013-02-02 +2 days' +%F`_repeat:+2")
+  else
+    expected=("command_do_$TASK" "command_add_`date +%F`_This_is_the_eleventh_line_due:`date -j -v+2d -f %F 2013-03-03 +%F`_t:`date -j -v+2d -f %F 2013-02-02 +%F`_repeat:+2")
+  fi
+  export TEST_EXPECT=`echo ${expected[@]}`
+  $AGAIN $TASK
+  TEST_FAILS=$(($TEST_FAILS + $?))
+  unset TODO_AGAIN_TAG
+}
+
 function test_day_stepping()
 {
   TASK=9
@@ -388,6 +404,7 @@ test_line_with_creation_date_and_prio
 test_nonexisting_line
 test_line_with_again_tag
 test_command_line_overrides_again_tag
+test_environment_variable_overrides_again_tag
 test_day_stepping
 test_week_stepping
 test_month_stepping


### PR DESCRIPTION
This allows for overriding the tag used for the adjustment interval in a task, allowing for compatibility with other tools (or just personal preference).