### PR TITLE
Use realpath so we can find againHelpers.sh

### DIFF
--- a/again
+++ b/again
@@ -17,7 +17,7 @@
 #You should have received a copy of the GNU General Public License
 #along with again.  If not, see <http://www.gnu.org/licenses/>.
 
-source `dirname $0`/againHelpers.sh
+source `dirname $(realpath $0)`/againHelpers.sh
 
 readonly SED_DATE_RE="[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}"
 readonly BASH_DATE_RE="[0-9]{4}-[0-9]{2}-[0-9]{2}"

--- a/again
+++ b/again
@@ -17,7 +17,7 @@
 #You should have received a copy of the GNU General Public License
 #along with again.  If not, see <http://www.gnu.org/licenses/>.
 
-source `dirname $(realpath $0)`/againHelpers.sh
+source `dirname $(realpath $0 || echo $0)`/againHelpers.sh
 
 readonly SED_DATE_RE="[0-9]\{4\}-[0-9]\{2\}-[0-9]\{2\}"
 readonly BASH_DATE_RE="[0-9]{4}-[0-9]{2}-[0-9]{2}"


### PR DESCRIPTION
even when `again` is only a symlink in `actions.de`

I had made this change many years ago, but never upstreamed it. The pattern I use to install add-ons in todo-txt is following: I git clone them a folder and then create a symlink from actions.d to it. When I do this with `again`it fails to find `againHelpers.sh`. This simple patch changes that.